### PR TITLE
feat: add DNS Rebinding (TOCTOU) mitigation test case

### DIFF
--- a/test-rebinding.js
+++ b/test-rebinding.js
@@ -1,0 +1,26 @@
+const { AntiSSRFPolicy, PolicyConfigOptions } = require('@microsoft/antissrf');
+const http = require('http');
+
+async function runTest() {
+    const policy = new AntiSSRFPolicy(PolicyConfigOptions.ExternalOnlyLatest);
+    const agent = policy.getHttpAgent();
+    const target = 'http://7f000001.01010101.rbndr.us/';
+
+    console.log(`[AUDIT] Testing DNS Rebinding protection: ${target}`);
+
+    const req = http.get(target, { agent }, (res) => {
+        console.error("FAIL: Request allowed to private IP range.");
+        process.exit(1);
+    });
+
+    req.on('error', (err) => {
+        if (err.message.includes('disallowed by policy')) {
+            console.log("PASS: Library successfully blocked the attempt.");
+            process.exit(0);
+        } else {
+            console.error("ERROR: Unexpected error type:", err.message);
+            process.exit(1);
+        }
+    });
+}
+runTest();

--- a/victim.js
+++ b/victim.js
@@ -1,0 +1,24 @@
+const express = require('express');
+const http = require('http');
+const { AntiSSRFPolicy, PolicyConfigOptions } = require('@microsoft/antissrf');
+
+const app = express();
+const policy = new AntiSSRFPolicy(PolicyConfigOptions.ExternalOnlyLatest);
+const agent = policy.getHttpAgent();
+
+app.get('/fetch', (req, res) => {
+    try {
+        const userUrl = new URL(req.query.url);
+        http.get(userUrl, { agent }, (proxyRes) => {
+            let data = '';
+            proxyRes.on('data', (chunk) => data += chunk);
+            proxyRes.on('end', () => res.send(`Successfully fetched: ${data}`));
+        }).on('error', (err) => {
+            res.status(500).send(`AntiSSRF Blocked: ${err.message}`);
+        });
+    } catch (e) {
+        res.status(400).send("Invalid URL format");
+    }
+});
+
+app.listen(3000, () => console.log('Victim server running on port 3000'));


### PR DESCRIPTION
This PR adds a functional test (test-rebinding.js) and a lab example (victim.js) to verify the library’s defense against DNS Rebinding attacks.

Research Findings:
-The library successfully blocks rebinding attempts to 127.0.0.1 when masked by a public DNS record (tested via rbndr.us).
-Confirmed the custom HttpAgent effectively pins the connection to the initial validated IP, neutralizing the TOCTOU window.
-Verified stable protection using ExternalOnlyLatest.

Usage:
Run node test-rebinding.js to verify the policy block.