### PR TITLE
 Fix broken documentation links in getting-started.md

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -78,10 +78,10 @@ The AntiSSRF library provides validation for different scenarios based on your t
 
 | Use Case | Description | Documentation Link |
 |----------|-------------|-------------------|
-| **General Case** | The untrusted URL can belong to **any domain** or an **untrusted domain**. | [.NET](../dotnet-api/antissrfpolicy) \| [Node.js](../nodejs-api/antissrfpolicy) |
-| **Azure Key Vault Domain** | The untrusted URL must be an **Azure Key Vault endpoint**. | [.NET](../dotnet-api/urivalidator/inazurekeyvaultdomain) \| [Node.js](../nodejs-api/urivalidator/inazurekeyvaultdomain) |
-| **Azure Storage Domain** | The untrusted URL must be an **Azure Storage endpoint**. | [.NET](../dotnet-api/urivalidator/inazurestoragedomain/) \| [Node.js](../nodejs-api/urivalidator/inazurestoragedomain/) |
-| **Allowlist of Trusted Domains** | The untrusted URL must belong to a **specific, trusted domain**. | [.NET](../dotnet-api/urivalidator/indomain/) \| [Node.js](../nodejs-api/urivalidator/indomain/) |
+| **General Case** | The untrusted URL can belong to **any domain** or an **untrusted domain**. | [.NET](dotnet-api/antissrfpolicy/) \| [Node.js](nodejs-api/antissrfpolicy/) |
+| **Azure Key Vault Domain** | The untrusted URL must be an **Azure Key Vault endpoint**. | [.NET](dotnet-api/urivalidator/inazurekeyvaultdomain) \| [Node.js](nodejs-api/urivalidator/inazurekeyvaultdomain) |
+| **Azure Storage Domain** | The untrusted URL must be an **Azure Storage endpoint**. | [.NET](dotnet-api/urivalidator/inazurestoragedomain) \| [Node.js](nodejs-api/urivalidator/inazurestoragedomain) |
+| **Allowlist of Trusted Domains** | The untrusted URL must belong to a **specific, trusted domain**. | [.NET](dotnet-api/urivalidator/indomain) \| [Node.js](nodejs-api/urivalidator/indomain) |
 
 ## Best Practices
 
@@ -105,8 +105,8 @@ The AntiSSRF library provides validation for different scenarios based on your t
 ## Next Steps
 
 ### Learn More
-- 📖 **API Documentation**: [.NET API](../dotnet-api) \| [Node.js API](../nodejs-api)
-- ❓ **Common Questions**: [FAQ](../faq)
+- 📖 **API Documentation**: [.NET API](dotnet-api/) \| [Node.js API](nodejs-api/)
+- ❓ **Common Questions**: [FAQ](faq)
 
 ### Get Support
 


### PR DESCRIPTION
Fixes Issue #22

The "How to Use" table and "Next Steps" section in docs/getting-started.md contain 11 broken relative links. All links incorrectly use ../ which
navigates one level above the docs/ directory, but the target pages (dotnet-api/, nodejs-api/, faq) are siblings within docs/.

Changes:

 - Removed the extra ../ prefix from all 11 relative links
 - Ensured directory paths (with index.md) end with /
 - Ensured single-file paths don't include .md/.html extensions or trailing /