### PR TITLE
Documentation Typos and Broken Links

### DIFF
--- a/.github/ISSUE_TEMPLATE/documentation_suggestion.yml
+++ b/.github/ISSUE_TEMPLATE/documentation_suggestion.yml
@@ -1,0 +1,49 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+name: Documentation Issue or Suggestion
+description: Report an issue or suggest an improvement to the AntiSSRF documentation
+title: "[Docs]: <title>"
+labels: ["documentation"]
+body:
+
+  - type: textarea
+    attributes:
+      label: Documentation Location
+      description: Link to the documentation page or identify the section that needs improvement.
+      placeholder: "e.g., https://microsoft.github.io/AntiSSRF/nodejs-api/urivalidator/indomain"
+    validations:
+      required: false
+
+  - type: textarea
+    attributes:
+      label: Description of the Issue or Suggestion
+      description: Describe what should be added, changed, clarified, or removed.
+    validations:
+      required: false
+
+  - type: textarea
+    attributes:
+      label: Why This Would Help
+      description: Explain the problem this improvement would solve or the question it would answer.
+    validations:
+      required: false
+
+  - type: textarea
+    attributes:
+      label: Additional Context
+      description: Provide any examples, screenshots, related links, or other context that may help us evaluate the suggestion.
+    validations:
+      required: false
+
+  - type: checkboxes
+    attributes:
+      label: Verification
+      description: Please confirm before submitting your suggestion.
+      options:
+        - label: I have searched existing issues and confirmed this suggestion has not already been submitted
+          required: true
+
+  - type: markdown
+    attributes:
+      value: "Thank you for helping us improve the AntiSSRF documentation!"

--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -33,8 +33,6 @@ jobs:
   # Build job
   build:
     runs-on: ubuntu-latest
-    env:
-      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -45,7 +43,7 @@ jobs:
           bundler-cache: true
           working-directory: ./docs
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
       - name: Build with Jekyll
         run: |
           cd docs

--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Build with Jekyll
         run: |
           cd docs
-          bundle exec jekyll build --destination ./_site
+          bundle exec jekyll build --destination _site/AntiSSRF
         env:
           JEKYLL_ENV: production
       - name: Validate generated HTML
@@ -60,7 +60,7 @@ jobs:
         if: github.event_name == 'push'
         uses: actions/upload-pages-artifact@v3
         with:
-          path: ./docs/_site
+          path: ./docs/_site/AntiSSRF
 
   # Deployment job
   deploy:

--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -52,6 +52,10 @@ jobs:
           bundle exec jekyll build --destination ./_site
         env:
           JEKYLL_ENV: production
+      - name: Validate generated HTML
+        run: |
+          cd docs
+          bundle exec htmlproofer ./_site --disable-external
       - name: Upload artifact
         if: github.event_name == 'push'
         uses: actions/upload-pages-artifact@v3

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -7,7 +7,7 @@ source "https://rubygems.org"
 # -- OR --
 #
 # bundle install
-# bundle exec jekyll build --baseurl ""
+# bundle exec jekyll build --destination _site/AntiSSRF
 # bundle exec htmlproofer _site --disable-external
 #
 

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,37 +1,42 @@
 source "https://rubygems.org"
-# Hello! This is where you manage which Jekyll version is used to run.
-# When you want to use a different version, change it below, save the
-# file and run `bundle install`. Run Jekyll with `bundle exec`, like so:
+
 #
-#     bundle exec jekyll serve
+# bundle install
+# bundle exec jekyll serve
 #
+# -- OR --
+#
+# bundle install
+# bundle exec jekyll build --baseurl ""
+# bundle exec htmlproofer _site --disable-external
+#
+
 # This will help ensure the proper Jekyll version is running.
-# Happy Jekylling!
 gem "jekyll", "~> 4.3.3"
 # Using Just the Docs theme for documentation
 gem "just-the-docs", "0.10.0"
 # Required for Ruby 3.4+ compatibility
 gem "csv", "~> 3.0"
 gem "base64", "~> 0.1"
-# If you want to use GitHub Pages, remove the "gem "jekyll"" above and
-# uncomment the line below. To upgrade, run `bundle update github-pages`.
-# gem "github-pages", "~> 232", group: :jekyll_plugins
-# If you have any plugins, put them here!
+
 group :jekyll_plugins do
-  gem "jekyll-feed", "~> 0.12"
   gem "jekyll-sitemap", "~> 1.4"
 end
 
 # Windows and JRuby does not include zoneinfo files, so bundle the tzinfo-data gem
 # and associated library.
-platforms :mingw, :x64_mingw, :mswin, :jruby do
+platforms :windows, :jruby do
   gem "tzinfo", ">= 1", "< 3"
   gem "tzinfo-data"
 end
 
 # Performance-booster for watching directories on Windows
-gem "wdm", "~> 0.1", :platforms => [:mingw, :x64_mingw, :mswin]
+gem "wdm", "~> 0.1", :platforms => [:windows]
 
 # Lock `http_parser.rb` gem to `v0.6.x` on JRuby builds since newer versions of the gem
 # do not have a Java counterpart.
 gem "http_parser.rb", "~> 0.6.0", :platforms => [:jruby]
+
+group :test do
+  gem "html-proofer"
+end

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -36,7 +36,6 @@ theme: just-the-docs
 remote_theme: just-the-docs/just-the-docs@v0.10.0
 
 plugins:
-  - jekyll-feed
   - jekyll-sitemap
 
 # Just the Docs configuration
@@ -78,14 +77,10 @@ callouts:
 # Footer content
 footer_content: "Copyright &copy; 2026 Microsoft Corporation. Distributed under the <a href=\"https://github.com/Microsoft/AntiSSRF/tree/main/LICENSE\">MIT license.</a>"
 
-# Google Analytics (optional)
-# ga_tracking: UA-XXXXXXXX-X
-# ga_tracking_anonymize_ip: true
-
 # Aux links for the upper right navigation
 aux_links:
   "AntiSSRF on GitHub":
-    - "//github.com/Microsoft/AntiSSRF"
+    - "https://github.com/Microsoft/AntiSSRF"
 
 # Makes Aux links open in a new tab
 aux_links_new_tab: false

--- a/docs/dotnet-api/antissrfpolicy/constructor.md
+++ b/docs/dotnet-api/antissrfpolicy/constructor.md
@@ -27,7 +27,7 @@ Choose from the following predefined policy configurations:
 
 | Option | Use Case | Behavior |
 | --- | --- | --- |
-| **InternalOnly** | Making requests to internal, non-public addresses only **OR** restricting requests to specific allowed addresses | Blocks all IP addresses by default. Only allows addresses explicitly added via [AddAllowedAddresses](../methods/addallowedaddresses). |
+| **InternalOnly** | Making requests to internal, non-public addresses only **OR** restricting requests to specific allowed addresses | Blocks all IP addresses by default. Only allows addresses explicitly added via [AddAllowedAddresses](./methods/addallowedaddresses). |
 | **ExternalOnlyV1** | Making requests to external APIs while blocking internal access | Blocks internal and special-purpose IP addresses per [IPAddressRanges.recommendedV1](../../ipaddressranges#recommendedrangesv1). Automatically adds `X-Forwarded-For` header to requests. |
 | **ExternalOnlyLatest** | Currently the same as `ExternalOnlyV1` with automatic security updates | Always stays up to date with the latest `ExternalOnly` version, independent of semantic versioning. |
 | **None** | Custom policy configuration | No restrictions applied. Requires manual configuration via policy methods. |
@@ -43,7 +43,7 @@ If your service needs to make requests to external endpoints, you need to make s
 
 If your service needs to make requests to backend services, you must prevent data exfiltration by ensuring it cannot be used to send data to external endpoints. In this case, we recommend using `PolicyConfigOptions.InternalOnly` to block all unspecified addresses, then use `AddAllowedAddresses(...)` with the specific internal IP addresses that your service might need to access.
 
-For more about the `X-Forwarded-For` header, see [addXFFHeader](../properties/addxffheader).
+For more about the `X-Forwarded-For` header, see [addXFFHeader](./properties/addxffheader).
 
 ## Immutability After Handler Creation
 

--- a/docs/dotnet-api/antissrfpolicy/constructor.md
+++ b/docs/dotnet-api/antissrfpolicy/constructor.md
@@ -28,7 +28,7 @@ Choose from the following predefined policy configurations:
 | Option | Use Case | Behavior |
 | --- | --- | --- |
 | **InternalOnly** | Making requests to internal, non-public addresses only **OR** restricting requests to specific allowed addresses | Blocks all IP addresses by default. Only allows addresses explicitly added via [AddAllowedAddresses](./methods/addallowedaddresses). |
-| **ExternalOnlyV1** | Making requests to external APIs while blocking internal access | Blocks internal and special-purpose IP addresses per [IPAddressRanges.recommendedV1](../../ipaddressranges#recommendedrangesv1). Automatically adds `X-Forwarded-For` header to requests. |
+| **ExternalOnlyV1** | Making requests to external APIs while blocking internal access | Blocks internal and special-purpose IP addresses per [IPAddressRanges.recommendedV1](../../ipaddressranges#recommended-ranges-v1). Automatically adds `X-Forwarded-For` header to requests. |
 | **ExternalOnlyLatest** | Currently the same as `ExternalOnlyV1` with automatic security updates | Always stays up to date with the latest `ExternalOnly` version, independent of semantic versioning. |
 | **None** | Custom policy configuration | No restrictions applied. Requires manual configuration via policy methods. |
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -46,7 +46,7 @@ policy.AddXFFHeader = false; // Disables automatic X-Forwarded-For header additi
 * Your destination service drops ALL requests with the `X-Forwarded-For` header. For example, you are intentionally accessing IMDS while blocking all external IP addresses.
 * **OR** another component in your service stack reliably adds the `X-Forwarded-For` header to all outgoing requests. That way, the policy does not need to add the invalid dummy value to include the header.
 
-For more information, see the [X-Forwarded-For security notes](../dotnet-api/antissrfpolicy/properties/addxffheader#security-notes) and `AddXFFHeader` property.
+For more information, see the [X-Forwarded-For security notes](dotnet-api/antissrfpolicy/properties/addxffheader#security-notes) and `AddXFFHeader` property.
 
 ## Should Microsoft services be onboarding to this library?
 

--- a/docs/nodejs-api/antissrfpolicy/constructor.md
+++ b/docs/nodejs-api/antissrfpolicy/constructor.md
@@ -29,7 +29,7 @@ Choose from the following predefined policy configurations:
 | Option | Use Case | Behavior |
 | --- | --- | --- |
 | **InternalOnly** | Making requests to internal, non-public addresses only **OR** restricting requests to specific allowed addresses | Blocks all IP addresses by default. Only allows addresses explicitly added via [addAllowedAddresses](./methods/addallowedaddresses). |
-| **ExternalOnlyV1** | Making requests to external APIs while blocking internal access | Blocks internal and special-purpose IP addresses per [IPAddressRanges.recommendedV1](../../ipaddressranges#recommendedrangesv1). Automatically adds `X-Forwarded-For` header to requests. |
+| **ExternalOnlyV1** | Making requests to external APIs while blocking internal access | Blocks internal and special-purpose IP addresses per [IPAddressRanges.recommendedV1](../../ipaddressranges#recommended-ranges-v1). Automatically adds `X-Forwarded-For` header to requests. |
 | **ExternalOnlyLatest** | Currently the same as `ExternalOnlyV1` with automatic security updates | Always stays up to date with the latest `ExternalOnly` version, independent of semantic versioning. |
 | **None** | Custom policy configuration | No restrictions applied. Requires manual configuration via policy methods. |
 

--- a/docs/nodejs-api/antissrfpolicy/constructor.md
+++ b/docs/nodejs-api/antissrfpolicy/constructor.md
@@ -28,7 +28,7 @@ Choose from the following predefined policy configurations:
 
 | Option | Use Case | Behavior |
 | --- | --- | --- |
-| **InternalOnly** | Making requests to internal, non-public addresses only **OR** restricting requests to specific allowed addresses | Blocks all IP addresses by default. Only allows addresses explicitly added via [addAllowedAddresses](../methods/addallowedaddresses). |
+| **InternalOnly** | Making requests to internal, non-public addresses only **OR** restricting requests to specific allowed addresses | Blocks all IP addresses by default. Only allows addresses explicitly added via [addAllowedAddresses](./methods/addallowedaddresses). |
 | **ExternalOnlyV1** | Making requests to external APIs while blocking internal access | Blocks internal and special-purpose IP addresses per [IPAddressRanges.recommendedV1](../../ipaddressranges#recommendedrangesv1). Automatically adds `X-Forwarded-For` header to requests. |
 | **ExternalOnlyLatest** | Currently the same as `ExternalOnlyV1` with automatic security updates | Always stays up to date with the latest `ExternalOnly` version, independent of semantic versioning. |
 | **None** | Custom policy configuration | No restrictions applied. Requires manual configuration via policy methods. |
@@ -44,4 +44,4 @@ If your service needs to make requests to external endpoints, you need to make s
 
 If your service needs to make requests to backend services, you must prevent data exfiltration by ensuring it cannot be used to send data to external endpoints. In this case, we recommend using `PolicyConfigOptions.InternalOnly` to block all unspecified addresses, then use `addAllowedAddresses(...)` with the specific internal IP addresses that your service might need to access.
 
-For more about the `X-Forwarded-For` header, see [addXFFHeader](../properties/addxffheader).
+For more about the `X-Forwarded-For` header, see [addXFFHeader](./properties/addxffheader).

--- a/docs/nodejs-api/samples/follow-redirects.md
+++ b/docs/nodejs-api/samples/follow-redirects.md
@@ -34,8 +34,8 @@ const policy = new AntiSSRFPolicy(PolicyConfigOptions.ExternalOnlyLatest);
 
 // Get the AntiSSRF agents
 const agents = {
-    httpAgent: policy.getHttpAgent(),
-    httpsAgent: policy.getHttpsAgent({ keepAlive: true })
+    http: policy.getHttpAgent(),
+    https: policy.getHttpsAgent({ keepAlive: true })
 }
 ```
 

--- a/docs/nodejs-api/urivalidator/indomain.md
+++ b/docs/nodejs-api/urivalidator/indomain.md
@@ -32,10 +32,12 @@ Validates if a URL belongs to any of a list of trusted domains.
 
 | Method | Description |
 | --------------- | --------------- |
-| [inDomain(URL \| string, string): boolean](#indomainurl-url--string-domain-boolean) | Validates if a URL belongs to a trusted domain. |
-| [inDomain(URL \| string, string[]): boolean](#indomainurl-url--string-domains-string-boolean) | Validates if a URL belongs to any of a list of trusted domains. |
+| [inDomain(URL \| string, string): boolean](#single-trusted-domain) | Validates if a URL belongs to a trusted domain. |
+| [inDomain(URL \| string, string[]): boolean](#trusted-domains) | Validates if a URL belongs to any of a list of trusted domains. |
 
-## inDomain(URL | string, string): boolean
+<h2 id="single-trusted-domain">
+    inDomain(URL | string, string): boolean
+</h2>
 
 ```js
 inDomain(untrustedUrl: URL | string, trustedDomain: string): boolean
@@ -56,8 +58,9 @@ The domain name that `untrustedUrl` will be compared against.
 * `true` if `untrustedUrl` belongs to `trustedDomain`.
 * `false` if `untrustedUrl` does not belong to `trustedDomain`, if `untrustedUrl` cannot be converted to a valid `URL`, if protocol is not HTTP/S or WS/S, or if either argument is invalid.
 
-
-## inDomain(URL | string, string[]): boolean
+<h2 id="trusted-domains">
+    inDomain(URL | string, string[]): boolean
+</h2>
 
 ```js
 inDomain(untrustedUrl: URL | string, trustedDomains: string[]): boolean


### PR DESCRIPTION
* Fix typo in Node.js sample docs for follow-redirects
* Fix broken links
* Enforce checks for broken links
* Add a new issue template to make it easier to suggest documentation changes