### PR TITLE
Fix socketPath policy bypass in Node.js agents

### DIFF
--- a/nodejs/src/Helpers/AntiSSRFHttpAgent.ts
+++ b/nodejs/src/Helpers/AntiSSRFHttpAgent.ts
@@ -77,9 +77,11 @@ export class AntiSSRFHttpAgent extends HttpAgent {
      */
     createConnection = (options: any, callback: any) => {
         // Ensure the user does not expect to use a different dns.lookup function
-        if (options?.lookup != null) {
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call
-            return callback(new AntiSSRFError("Cannot use AntiSSRFHttpAgent with custom lookup function"), null);
+        if (options?.socketPath != null) {
+            return callback(
+                new AntiSSRFError("Cannot use AntiSSRF agent with socketPath"),
+                null
+            );
         }
 
         // http.request host is supposed to default to localhost. We want to

--- a/nodejs/src/Helpers/AntiSSRFHttpsAgent.ts
+++ b/nodejs/src/Helpers/AntiSSRFHttpsAgent.ts
@@ -78,9 +78,11 @@ export class AntiSSRFHttpsAgent extends HttpsAgent {
      */
     createConnection = (options: any, callback: any) => {
         // Ensure the user does not expect to use a different dns.lookup function
-        if (options?.lookup != null) {
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call
-            return callback(new AntiSSRFError("Cannot use AntiSSRFHttpsAgent with custom lookup function"), null);
+        if (options?.socketPath != null) {
+            return callback(
+                new AntiSSRFError("Cannot use AntiSSRF agent with socketPath"),
+                null
+            );
         }
 
         // https.request host is supposed to default to localhost. We want to


### PR DESCRIPTION
Fixes #40

The Node.js AntiSSRF HTTP and HTTPS agents validate IP destinations
through createConnection(), but socketPath requests can bypass that
network-destination policy because Unix-domain sockets do not have an
IP destination.

This change explicitly rejects socketPath requests in both agents
instead of delegating them to the parent Node.js agent.